### PR TITLE
fixing the crashing bug

### DIFF
--- a/app/src/main/java/com/elliottsoftware/calftracker/presentation/components/subscription/SubscriptionView.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/presentation/components/subscription/SubscriptionView.kt
@@ -56,7 +56,7 @@ fun SubscriptionView(
 @SuppressLint("UnusedMaterialScaffoldPaddingParameter")
 @Composable
 fun SubscriptionViews(
-    subscriptionViewModel: SubscriptionViewModel = viewModel(),
+   // subscriptionViewModel: SubscriptionViewModel = viewModel(),
     onNavigate: (Int) -> Unit = {},
     billingViewModel:BillingViewModel = viewModel()
 ){


### PR DESCRIPTION
# Related Issue
- #300  

# Proposed changes
- All I did was comment out the `// subscriptionViewModel: SubscriptionViewModel = viewModel()`. This fixes the crash but will need to be revisited to get the subscriptions back working.

# Additional info
- I think this has something to do with the lifecycle of the ViewModels when mixing the `viewModel()` and `activityViewModel()`
