### PR TITLE
adding the loading screen and disabling the buy button when loading

### DIFF
--- a/app/src/main/java/com/elliottsoftware/calftracker/presentation/components/subscription/BillingViewModel.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/presentation/components/subscription/BillingViewModel.kt
@@ -46,7 +46,8 @@ data class BillingUiState(
             ),
     val nextBillingPeriod:String =" None",
     val calfListSize:Int = 0,
-    val isUserSubscribed: Boolean = false
+    val isUserSubscribed: Boolean = false,
+    val userBuying:Boolean = false
 
 )
 
@@ -287,6 +288,9 @@ class BillingViewModel @Inject constructor(
         tag: String
     ) {
 
+        _uiState.value = _uiState.value.copy(
+            userBuying = true
+        )
         val offers =
             productDetails.subscriptionOfferDetails?.let {
                 retrieveEligibleOffers(
@@ -449,7 +453,10 @@ class BillingViewModel @Inject constructor(
 
 
     override fun onResume(owner: LifecycleOwner) {
-        Timber.tag("substuff").d("ONRESUME CALLED")
+        _uiState.value = _uiState.value.copy(
+            userBuying = false
+        )
+
         refreshPurchases()
         subscribedPurchases()
         checkUserSubscription()

--- a/app/src/main/java/com/elliottsoftware/calftracker/presentation/components/subscription/SubscriptionView.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/presentation/components/subscription/SubscriptionView.kt
@@ -89,6 +89,7 @@ fun SubscriptionViewExample(
     val loadingState = remember { mutableStateOf(false) }
     val lazyListState = rememberLazyListState()
     val isUserSubscribed = billingViewModel.state.value.isUserSubscribed
+    val isUserBuying = billingViewModel.state.value.userBuying
 
 
 
@@ -112,20 +113,7 @@ fun SubscriptionViewExample(
 
 
         }
-        //THE LOADING INDICATOR
-        if(loadingState.value){
-            Spacer(
-                modifier = Modifier
-                    .matchParentSize()
-                    .background(color = Color.Gray.copy(alpha = .7f))
-            )
-            CircularProgressIndicator(
-                color= MaterialTheme.colors.onSecondary,
-                modifier = Modifier
-                    .align(Alignment.Center)
-                    .size(60.dp)
-            )
-        }
+
 
 
     }//end of the box
@@ -182,47 +170,73 @@ fun SubscriptionViews(
     bottomModalState: ModalBottomSheetState,
     mainViewModel: MainViewModel
 ){
+    //THE LOADING INDICATOR
+    val isUserBuying = billingViewModel.state.value.userBuying
+
 
     val scope = rememberCoroutineScope()
-    Scaffold(
-        backgroundColor = MaterialTheme.colors.primary,
-        topBar = {
-            TopBar(
-                onNavigate = onNavigate
+    Box(modifier = Modifier
+        .fillMaxSize()){
+        Scaffold(
+            backgroundColor = MaterialTheme.colors.primary,
+            topBar = {
+                TopBar(
+                    onNavigate = onNavigate
+                )
+            },
+            bottomBar = {
+                BottomButton(billingViewModel = billingViewModel)
+            }
+        ){paddingValues ->
+
+            SubscriptionViewExample(
+                billingViewModel = billingViewModel,
+                paddingValues = paddingValues
             )
-        },
-        bottomBar = {
-            BottomButton(billingViewModel = billingViewModel)
+
+
         }
-    ){paddingValues ->
+        if(isUserBuying){
+            Spacer(
+                modifier = Modifier
+                    .matchParentSize()
+                    .background(color = Color.Gray.copy(alpha = .7f))
+            )
+            CircularProgressIndicator(
+                color= MaterialTheme.colors.onSecondary,
+                modifier = Modifier
+                    .align(Alignment.Center)
+                    .size(60.dp)
+            )
+        }
 
-        SubscriptionViewExample(
-            billingViewModel = billingViewModel,
-            paddingValues = paddingValues
-        )
 
+    } // end of the Box
 
-    }
 }
 
 @Composable
 fun BottomButton(billingViewModel:BillingViewModel){
     val context = LocalContext.current
     val activity = context.findActivity()
+    val isUserBuying = billingViewModel.state.value.userBuying
     Row(
         modifier = Modifier.padding(10.dp).fillMaxWidth(),
         horizontalArrangement = Arrangement.Center
     ){
         Button(
             onClick={
-                billingViewModel.state.value.productDetails?.let{
-                    billingViewModel.buy(
-                        productDetails = it,
-                        currentPurchases = null,
-                        activity = activity,
-                        tag = "calf_tracker_premium"
-                    )
+                if(!isUserBuying){
+                    billingViewModel.state.value.productDetails?.let{
+                        billingViewModel.buy(
+                            productDetails = it,
+                            currentPurchases = null,
+                            activity = activity,
+                            tag = "calf_tracker_premium"
+                        )
+                    }
                 }
+
             }
         ){
             Text("Upgrade $10.00", fontSize = 30.sp)


### PR DESCRIPTION
# Related Issue
- #326 

# Proposed changes
- adding a loading screen after the buy button is pressed
- disabling the buy button after it is pressed and making it work again after onResume() is called

