### PR TITLE
reworking the loginUser() method

### DIFF
--- a/app/src/main/java/com/elliottsoftware/calftracker/data/sources/AuthenticatioSource.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/data/sources/AuthenticatioSource.kt
@@ -12,7 +12,8 @@ interface AuthenticationSource {
 
     fun createUserWithEmailAndPassword(email:String,password:String): Flow<Response<Boolean>>
 
-    fun signInWithEmailAndPassword(email:String, password:String): Flow<Response<Boolean>>
+    fun loginWithEmailAndPassword(email:String, password:String): Flow<Response<Boolean>>
+
 
 //    fun currentUser():Boolean
 //

--- a/app/src/main/java/com/elliottsoftware/calftracker/data/sources/implementations/FireBaseAuthentication.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/data/sources/implementations/FireBaseAuthentication.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.tasks.await
+import timber.log.Timber
 
 class FireBaseAuthentication : AuthenticationSource {
 
@@ -44,12 +45,22 @@ class FireBaseAuthentication : AuthenticationSource {
         awaitClose()
     }
 
-    override fun signInWithEmailAndPassword(
-        email: String,
-        password: String
-    ): Flow<Response<Boolean>> {
-        TODO("Not yet implemented")
+    override fun loginWithEmailAndPassword(email: String, password: String)= callbackFlow {
+        trySend(Response.Loading)
+        auth.signInWithEmailAndPassword(email, password)
+            .addOnCompleteListener { task ->
+                if (task.isSuccessful) {
+                    trySend(Response.Success(true))
+                } else {
+                    // If sign in fails, display a message to the user.
+                    Timber.tag("LoginFailure").e(Exception(task.exception))
+                    trySend(Response.Failure(Exception()))
+                }
+            }
+
+        awaitClose()
     }
+
 
 //    override fun currentUser(): Boolean {
 //        TODO("Not yet implemented")

--- a/app/src/main/java/com/elliottsoftware/calftracker/domain/repositories/AuthRepository.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/domain/repositories/AuthRepository.kt
@@ -15,7 +15,7 @@ interface AuthRepository {
 
      fun createUser(email: String, username: String):Flow<Response<Boolean>>
 
-    suspend fun loginUser(email:String,password:String):Flow<Response<Boolean>>
+     fun loginUser(email:String,password:String):Flow<Response<Boolean>>
 
      fun isUserSignedIn():Boolean
 


### PR DESCRIPTION
# Related Issue
- #361 

# Proposed changes
- reworked the loginUser() method to use the authenticationSource interface
- renamed the authenticationSource from `thingers` to `authenticationSource`


# Additional info
- This not only makes the code easier to test but also makes the code more flexible to change


