### PR TITLE
reworked createCalf()

### DIFF
--- a/app/src/main/java/com/elliottsoftware/calftracker/data/sources/AuthenticatioSource.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/data/sources/AuthenticatioSource.kt
@@ -60,6 +60,8 @@ interface AuthenticationSource {
      */
     fun resetPassword(email:String): Flow<Response<Boolean>>
 
+    fun currentUserEmail():String
+
 
 
 

--- a/app/src/main/java/com/elliottsoftware/calftracker/data/sources/DatabaseSource.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/data/sources/DatabaseSource.kt
@@ -1,9 +1,15 @@
 package com.elliottsoftware.calftracker.data.sources
 
 import com.elliottsoftware.calftracker.domain.models.Response
+import com.elliottsoftware.calftracker.domain.models.fireBase.FireBaseCalf
 import kotlinx.coroutines.flow.Flow
 
 interface DatabaseSource {
 
     fun createUser(email: String, username: String): Flow<Response<Boolean>>
+
+    fun createCalf(
+        calf: FireBaseCalf,
+        userEmail: String
+    ): Flow<Response<Boolean>>
 }

--- a/app/src/main/java/com/elliottsoftware/calftracker/data/sources/implementations/FireBaseAuthentication.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/data/sources/implementations/FireBaseAuthentication.kt
@@ -95,4 +95,9 @@ class FireBaseAuthentication : AuthenticationSource {
         awaitClose()
     }
 
+    override fun currentUserEmail():String{
+        return auth.currentUser?.email!!
+
+    }
+
 }

--- a/app/src/main/java/com/elliottsoftware/calftracker/data/sources/implementations/FireBaseFireStore.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/data/sources/implementations/FireBaseFireStore.kt
@@ -2,12 +2,14 @@ package com.elliottsoftware.calftracker.data.sources.implementations
 
 import com.elliottsoftware.calftracker.data.sources.DatabaseSource
 import com.elliottsoftware.calftracker.domain.models.Response
+import com.elliottsoftware.calftracker.domain.models.fireBase.FireBaseCalf
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import timber.log.Timber
 
 class FireBaseFireStore:DatabaseSource {
     private val db: FirebaseFirestore = Firebase.firestore
@@ -27,6 +29,28 @@ class FireBaseFireStore:DatabaseSource {
                     e ->
                 trySend(Response.Failure(Exception(" Error! Please try again")))
             }
+
+        awaitClose()
+    }
+
+    override fun createCalf(calf: FireBaseCalf, userEmail: String): Flow<Response<Boolean>> = callbackFlow {
+        trySend(Response.Loading)
+
+            val collection = db.collection("users").document(userEmail)
+                .collection("calves")
+            val document = collection.document()
+            val id = document.id
+            calf.id = id
+
+            collection.document(id).set(calf)
+                .addOnSuccessListener { document ->
+                    Timber.d( "DocumentSnapshot written with ID: ${calf.id}")
+                    trySend(Response.Success(true))
+                }
+                .addOnFailureListener { e ->
+                    Timber.e( "Error adding document", e)
+                    trySend(Response.Failure(e))
+                }
 
         awaitClose()
     }

--- a/app/src/main/java/com/elliottsoftware/calftracker/domain/repositories/DatabaseRepository.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/domain/repositories/DatabaseRepository.kt
@@ -20,7 +20,7 @@ import com.elliottsoftware.calftracker.domain.models.NetworkResponse
 interface DatabaseRepository {
 
 
-    suspend fun createCalf(calf:FireBaseCalf):Flow<Response<Boolean>>
+     fun createCalf(calf:FireBaseCalf,userEmail:String):Flow<Response<Boolean>>
 
     suspend fun getCalves(queryLimit:Long):Flow<Response<List<FireBaseCalf>>>
 

--- a/app/src/main/java/com/elliottsoftware/calftracker/presentation/components/newCalf/NewCalfViewModel.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/presentation/components/newCalf/NewCalfViewModel.kt
@@ -11,6 +11,9 @@ import com.elliottsoftware.calftracker.domain.models.Response
 import com.elliottsoftware.calftracker.domain.models.fireBase.FireBaseCalf
 import com.elliottsoftware.calftracker.domain.repositories.DatabaseRepository
 import com.elliottsoftware.calftracker.domain.useCases.LogoutUseCase
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.ktx.auth
+import com.google.firebase.ktx.Firebase
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
@@ -55,6 +58,7 @@ class NewCalfViewModel @Inject constructor(
 
     private val _uiState = mutableStateOf(NewCalfUIState())
     val state:State<NewCalfUIState> = _uiState
+    private val auth: FirebaseAuth = Firebase.auth
 
     private val dispatcherIO: CoroutineDispatcher = Dispatchers.IO
 
@@ -138,7 +142,7 @@ class NewCalfViewModel @Inject constructor(
                 birthweight = state.birthWeight,
                 vaccinelist = vaccineList
             )
-            databaseRepository.createCalf(calf)
+            databaseRepository.createCalf(calf,auth.currentUser?.email!!)
                 .flowOn(dispatcherIO)
                 .collect{ response ->
                 _uiState.value = state.copy(calfSaved = response)


### PR DESCRIPTION
# Related Issue
- #367 

# Proposed changes
- reworked the createCalf() to use the `DatabaseSource` wrapper class
- Also, added the email parameter to createCalf(). This decouples the code even further from the authentication system

