### PR TITLE
reworking the deleteCalf() method

### DIFF
--- a/app/src/main/java/com/elliottsoftware/calftracker/data/repositories/DatabaseRepositoryImpl.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/data/repositories/DatabaseRepositoryImpl.kt
@@ -56,22 +56,13 @@ class DatabaseRepositoryImpl(
 
     }
 
-    override suspend fun deleteCalf(id: String)= callbackFlow {
-        Timber.d("IDBELOW")
-        Timber.d(id)
-       db.collection("users").document(auth.currentUser?.email!!)
-            .collection("calves").document(id).delete()
-            .addOnSuccessListener {
-                Timber.d("DELETE SUCCESS")
-                trySend(Response.Success(true))
-            }
-            .addOnFailureListener {
-                Timber.d("DELETE FAIL")
-                Timber.d(it)
-                trySend(Response.Failure(Exception("Delete Calf Error")))
+    override fun deleteCalf(id: String,userEmail: String):Flow<Response<Boolean>> {
+        val items = databaseSource.deleteCalf(id,userEmail)
+            .catch { cause: Throwable ->
+                emit(Response.Failure(Exception(" Error! Please try again")))
             }
 
-        awaitClose()
+        return items
 
     }
 

--- a/app/src/main/java/com/elliottsoftware/calftracker/data/sources/DatabaseSource.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/data/sources/DatabaseSource.kt
@@ -14,4 +14,6 @@ interface DatabaseSource {
     ): Flow<Response<Boolean>>
 
     fun getCalves(queryLimit:Long,userEmail: String): Flow<Response<List<FireBaseCalf>>>
+
+    fun deleteCalf(id: String,userEmail: String): Flow<Response<Boolean>>
 }

--- a/app/src/main/java/com/elliottsoftware/calftracker/data/sources/implementations/FireBaseFireStore.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/data/sources/implementations/FireBaseFireStore.kt
@@ -114,4 +114,21 @@ class FireBaseFireStore:DatabaseSource {
             docRef.remove()
         }
     }
+
+    override fun deleteCalf(id: String,userEmail: String): Flow<Response<Boolean>> = callbackFlow{
+
+        db.collection("users").document(userEmail)
+            .collection("calves").document(id).delete()
+            .addOnSuccessListener {
+
+                trySend(Response.Success(true))
+            }
+            .addOnFailureListener {
+                Timber.d(it)
+                trySend(Response.Failure(Exception("Delete Calf Error")))
+            }
+
+        awaitClose()
+
+    }
 }

--- a/app/src/main/java/com/elliottsoftware/calftracker/domain/repositories/DatabaseRepository.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/domain/repositories/DatabaseRepository.kt
@@ -24,7 +24,7 @@ interface DatabaseRepository {
 
      fun getCalves(queryLimit:Long,userEmail: String):Flow<Response<List<FireBaseCalf>>>
 
-    suspend fun deleteCalf(id:String):Flow<Response<Boolean>>
+     fun deleteCalf(id:String,userEmail: String):Flow<Response<Boolean>>
 
     suspend fun updateCalf(fireBaseCalf: FireBaseCalf):Flow<Response<Boolean>>
 

--- a/app/src/main/java/com/elliottsoftware/calftracker/domain/useCases/DeleteCalfUseCase.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/domain/useCases/DeleteCalfUseCase.kt
@@ -2,18 +2,32 @@ package com.elliottsoftware.calftracker.domain.useCases
 
 import com.elliottsoftware.calftracker.data.repositories.DatabaseRepositoryImpl
 import com.elliottsoftware.calftracker.domain.models.Response
+import com.elliottsoftware.calftracker.domain.models.fireBase.FireBaseCalf
 import com.elliottsoftware.calftracker.domain.repositories.DatabaseRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
 
+//data class GetCalvesParams(
+//    val calfLimit:Long,
+//    val userEmail: String
+//)
+//class GetCalvesUseCase @Inject constructor(
+//    val databaseRepository: DatabaseRepository
+//):UseCase<GetCalvesParams,Flow<Response<List<FireBaseCalf>>>>() {
+
+data class DeleteCalfParams(
+    val calfId:String,
+    val userEmail:String
+)
+
 
 class DeleteCalfUseCase @Inject constructor(
     private val databaseRepository: DatabaseRepository
-):UseCase<String,Flow<Response<Boolean>>>() {
+):UseCase<DeleteCalfParams,Flow<Response<Boolean>>>() {
 
 
-    override suspend fun execute(params: String): Flow<Response<Boolean>> {
-        return databaseRepository.deleteCalf(params)
+    override suspend fun execute(params: DeleteCalfParams): Flow<Response<Boolean>> {
+        return databaseRepository.deleteCalf(id = params.calfId, userEmail = params.userEmail)
     }
 }

--- a/app/src/main/java/com/elliottsoftware/calftracker/presentation/components/main/MainViewModel.kt
+++ b/app/src/main/java/com/elliottsoftware/calftracker/presentation/components/main/MainViewModel.kt
@@ -140,7 +140,9 @@ class MainViewModel @Inject constructor(
     }
 
     fun deleteCalf(id:String) = viewModelScope.launch{
-        deleteCalfUseCase.execute(id)
+        deleteCalfUseCase.execute(
+            DeleteCalfParams(calfId =id, userEmail =auth.currentUser?.email!! )
+        )
             .flowOn(dispatcherIO)
             .collect{ response ->
 


### PR DESCRIPTION
# Related Issue
- #373 

# Proposed changes
- reworked the deleteCalf() method to use the database wrapper class instead of the hardcoded database value
- added exception handling

# Additional info
- This works fine but still need to give the user more feed back when a calf is deleted

